### PR TITLE
Judge and filter filename illegal keywords & Fixed renaming filename problem

### DIFF
--- a/DMR/Downloader/danmakuio.py
+++ b/DMR/Downloader/danmakuio.py
@@ -44,7 +44,7 @@ class DanmakuWriter():
         self.kwargs = kwargs
 
         self.lock = threading.Lock()
-        self.ntrack = int((height*dmrate - fontsize)/(fontsize+margin))
+        self.ntrack = int((height*dmrate - self.fontsize)/(self.fontsize+margin))
         self.trackinfo = [None for _ in range(self.ntrack)]
 
         self.meta_info = [

--- a/DMR/utils.py
+++ b/DMR/utils.py
@@ -1,6 +1,7 @@
 import subprocess
 import json
 import warnings
+import re
 
 from .LiveAPI import GetStreamerInfo, split_url, AVAILABLE_DANMU, AVAILABLE_LIVE
 
@@ -14,6 +15,8 @@ def replace_keywords(string:str, kw_info:dict=None):
                     string = string.replace('{'+f'{kw}'.upper()+'}', str(getattr(v,kw)).zfill(2))
                 else:
                     string = string.replace('{'+f'{kw}'.upper()+'}', str(getattr(v,kw)))
+        elif k == 'title':
+            string = string.replace('{'+f'{k}'.upper()+'}', re.sub(r"[\\/:*?\"<>|]", "", str(v)))
         string = string.replace('{'+f'{k}'.upper()+'}', str(v))
     return string
 
@@ -83,6 +86,12 @@ class Config():
         
         self.config = default_conf.copy()
         self.config['upload'] = {}
+
+        # check downloader output name validation
+        self.downloader_output_name = self.default_conf['downloader']['output_name']
+        self.downloader_output_name_check = re.sub(r"[\\/:*?\"<>|]", "", str(self.downloader_output_name))
+        if self.downloader_output_name_check != self.downloader_output_name:
+            raise ValueError(f'自定义录制文件名称不合法: {self.downloader_output_name}')
 
         if self.replay_conf.get('replay'):
             self.config['replay'] = {}


### PR DESCRIPTION
1. 增加了检测文件名是否合法的方法，并将其使用到直播间标题检测中。
2. 优化了重命名文件名中时间的命名方法，现在时间能更加精准的表示出来了。
3. 将获取直播间信息的时间提前至分片刚开始录制的时候，而不是分片录制完毕后才获取。