### PR TITLE
feat(biliup-rs): tag支持列表形式

### DIFF
--- a/DMR/Uploader/biliuprs.py
+++ b/DMR/Uploader/biliuprs.py
@@ -184,6 +184,8 @@ class biliuprs():
         if config.get('dynamic'):
             config['dynamic'] = replace_keywords(config['dynamic'], video_info, replace_invalid=replace_invalid)
         if config.get('tag'):
+            if isinstance(config['tag'], list):
+                config['tag'] = ','.join(config['tag'])
             config['tag'] = replace_keywords(config['tag'], video_info, replace_invalid=replace_invalid)
         if config.get('source'):
             config['source'] = replace_keywords(config['source'], video_info, replace_invalid=replace_invalid)


### PR DESCRIPTION
使其配置文件里的tag支持['x', 'xx']格式