### PR TITLE
feat(biliup-rs): tag为列表时，支持无引号替换

### DIFF
--- a/DMR/Uploader/biliuprs.py
+++ b/DMR/Uploader/biliuprs.py
@@ -185,7 +185,12 @@ class biliuprs():
             config['dynamic'] = replace_keywords(config['dynamic'], video_info, replace_invalid=replace_invalid)
         if config.get('tag'):
             if isinstance(config['tag'], list):
-                config['tag'] = ','.join(config['tag'])
+                tag = []
+                for data in config['tag']:
+                    if isinstance(data, dict):
+                        data = f"{{{''.join(data)}}}"
+                    tag.append(data)
+                config['tag'] = ','.join(tag)
             config['tag'] = replace_keywords(config['tag'], video_info, replace_invalid=replace_invalid)
         if config.get('source'):
             config['source'] = replace_keywords(config['source'], video_info, replace_invalid=replace_invalid)


### PR DESCRIPTION
改动后可以使得`[{STREAMER.NAME}]`也可以支持替换，但测完我感觉多此一举了(一开始我以为支持列表后不支持关键字替换了)，你看需不需要吧
正常这种`['{STREAMER.NAME}']`已经能替换了
