### PR TITLE
增加macOS安装方法以及Apple平台编码器加速说明

### DIFF
--- a/DMR/Config/default.yml
+++ b/DMR/Config/default.yml
@@ -218,7 +218,7 @@ render_args:
     format: mp4
     # 硬件解码参数，默认由FFmpeg自动判断，如果出现问题可以设为空
     hwaccel_args: [-hwaccel, auto]
-    # 视频编码器，NVIDIA设置为h264_nvenc，AMD设置为h264_amf，CPU设置为libx264
+    # 视频编码器，NVIDIA设置为h264_nvenc，AMD设置为h264_amf，Apple用户设置为h264_videotoolbox，CPU设置为libx264
     vencoder: h264_nvenc
     # 视频编码器参数，默认恒定码率15Mbps
     vencoder_args: [-b:v, 15M]
@@ -245,7 +245,7 @@ render_args:
     format: mp4
     # 硬件解码参数，默认由FFmpeg自动判断，如果出现问题可以设为空
     hwaccel_args: [-hwaccel, auto]
-    # 视频编码器，NVIDIA设置为h264_nvenc，AMD设置为h264_amf，CPU设置为libx264
+    # 视频编码器，NVIDIA设置为h264_nvenc，AMD设置为h264_amf，Apple用户设置为h264_videotoolbox，CPU设置为libx264
     vencoder: h264_nvenc
     # 视频编码器参数，默认恒定码率15Mbps
     vencoder_args: [-b:v, 15M]

--- a/configs/global.yml
+++ b/configs/global.yml
@@ -216,7 +216,7 @@ render_args:
     format: mp4
     # 硬件解码参数，默认由FFmpeg自动判断，如果出现问题可以设为空
     hwaccel_args: [-hwaccel, auto]
-    # 视频编码器，NVIDIA设置为h264_nvenc，AMD设置为h264_amf，CPU设置为libx264
+    # 视频编码器，NVIDIA设置为h264_nvenc，AMD设置为h264_amf，Apple用户设置为h264_videotoolbox，CPU设置为libx264
     vencoder: h264_nvenc
     # 视频编码器参数，默认恒定码率15Mbps
     vencoder_args: [-b:v, 15M]
@@ -243,7 +243,7 @@ render_args:
     format: mp4
     # 硬件解码参数，默认由FFmpeg自动判断，如果出现问题可以设为空
     hwaccel_args: [-hwaccel, auto]
-    # 视频编码器，NVIDIA设置为h264_nvenc，AMD设置为h264_amf，CPU设置为libx264
+    # 视频编码器，NVIDIA设置为h264_nvenc，AMD设置为h264_amf，Apple用户设置为h264_videotoolbox，CPU设置为libx264
     vencoder: h264_nvenc
     # 视频编码器参数，默认恒定码率15Mbps
     vencoder_args: [-b:v, 15M]

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,9 +4,10 @@
 **目录：**      
 [Windows安装](#Windows安装)     
 [Linux安装](#Linux安装)         
+[macOS安装](#macOS安装)         
 [备注](#备注)           
 
-更新日期：2023.8.10。     
+更新日期：2024.12.10。     
 
 ## Windows安装 
 
@@ -65,6 +66,43 @@ sudo apt-get install ffmpeg
 在录制斗鱼弹幕时需要JavaScript解释器，部分Linux并没有预装，需要手动安装（这里以nodejs为例）：
 ```shell
 sudo apt install nodejs npm
+```
+
+## macOS安装
+与Linux的安装方法基本类似，示例系统版本为macOS Sequoia 15.1.1。   
+
+1. 安装Python            
+macOS一般已经默认安装Python，使用命令`python -V`检测是否安装Python。如果没有请先安装 [Homebrew](https://brew.sh/) 之后输入以下指令安装：
+```shell
+brew install python@3.9
+```
+
+2. 安装程序     
+安装release版本的方法类似Windows，安装测试版的话可以使用git命令安装：
+```git
+git clone https://github.com/SmallPeaches/DanmakuRender.git -b v5
+```
+
+3. 安装Python包     
+打开 `终端` 应用程序，输入下面的命令安装Python包。    
+```shell
+pip install -r requirements.txt
+```
+
+4. 安装FFmpeg       
+使用Homebrew快速安装：
+```shell
+brew install ffmpeg
+```
+如果需要安装最新版本，请前往：https://ffmpeg.org/download.html      
+
+5. 安装biliup-rs        
+方法类似Linux安装，下载时选择macOS的预编译版本（根据处理器平台选择aarch64或x86_64版本）        
+
+6. 安装JavaScript解释器           
+在录制斗鱼弹幕时需要JavaScript解释器，macOS并没有预装，需要手动安装（这里以nodejs为例）：
+```shell
+brew install node
 ```
 
 ## 备注     

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -75,7 +75,7 @@ render_args:
   # 硬件解码参数，默认自动
   # 请注意，使用远程桌面时auto可能出现问题，请设置为空
   hwaccel_args: [-hwaccel,auto] 
-  # 使用NVIDIA H.264编码器，A卡用户设置为h264_amf，I卡设置为h264_qsv，CPU渲染设置为libx264
+  # 使用NVIDIA H.264编码器，A卡用户设置为h264_amf，I卡设置为h264_qsv，Apple用户设置为h264_videotoolbox，CPU渲染设置为libx264
   vencoder: h264_nvenc   
   # 指定编码器参数，默认15M码率         
   vencoder_args: ['-b:v','15M'] 
@@ -496,7 +496,7 @@ render_args:
     format: mp4
     # 硬件解码参数，默认由FFmpeg自动判断，如果出现问题可以设为空
     hwaccel_args: [-hwaccel, auto]
-    # 视频编码器，NVIDIA设置为h264_nvenc，AMD设置为h264_amf，CPU设置为libx264
+    # 视频编码器，NVIDIA设置为h264_nvenc，AMD设置为h264_amf，Apple用户设置为h264_videotoolbox，CPU设置为libx264
     vencoder: h264_nvenc
     # 视频编码器参数，默认恒定码率15Mbps
     vencoder_args: [-b:v, 15M]
@@ -523,7 +523,7 @@ render_args:
     format: mp4
     # 硬件解码参数，默认由FFmpeg自动判断，如果出现问题可以设为空
     hwaccel_args: [-hwaccel, auto]
-    # 视频编码器，NVIDIA设置为h264_nvenc，AMD设置为h264_amf，CPU设置为libx264
+    # 视频编码器，NVIDIA设置为h264_nvenc，AMD设置为h264_amf，Apple用户设置为h264_videotoolbox，CPU设置为libx264
     vencoder: h264_nvenc
     # 视频编码器参数，默认恒定码率15Mbps
     vencoder_args: [-b:v, 15M]


### PR DESCRIPTION
测试平台：Mac mini 2024 (Apple M4)
测试系统：macOS Sequoia 15.1.1
通过修改视频编码器为 `h264_videotoolbox` 获得飞一般的渲染体验