### PR TITLE
修复无法获取superchat的bug

### DIFF
--- a/DMR/utils/danmaku.py
+++ b/DMR/utils/danmaku.py
@@ -70,10 +70,12 @@ class SuperChatDanmaku(SimpleDanmaku):
         price: float = 0.0,
         price_unit: str = '',
         duration: int = 0,
+        name: str = '',
         *args,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
+        self.uname = name
         self.price = price
         self.price_unit = price_unit
         self.duration = duration


### PR DESCRIPTION
b站superchat的用户名在name中，原uname是空导致过滤获取不到