### PR TITLE
Add '-noautoscale' parameter to video rendering

### DIFF
--- a/DMR/Render/dmrender.py
+++ b/DMR/Render/dmrender.py
@@ -74,6 +74,7 @@ class DmRender(BaseRender):
             *self.vencoder_args,
             '-c:a', self.aencoder,
             *self.aencoder_args,
+            "-noautoscale", # 添加 -noautoscale 参数，解决在特定情况下错误缩放的问题
             *scale_args,
             output,
         ]


### PR DESCRIPTION
Added '-noautoscale' parameter to fix scaling issues in specific cases.
起初是我在N100+Ubuntu22.04发现了无法正常渲染弹幕
后来发现是ffmpeg错误的添加了缩放
如果要不添加这个参数还要解决这个问题，需要很长的滤镜链。这会造成N100的内存带宽耗尽的问题。

兼容性：已经询问了Gemini2.5Flash，不会有兼容性问题
```
以下是关于此参数及其在不同硬件上的兼容性的详细说明：

- 作用 ：当您使用 -noautoscale 参数时，FFmpeg 将会保留原始视频流的尺寸，不会进行任何自动的缩放操作。这在您希望精确控制视频输出尺寸，或者不希望 FFmpeg 自动干预视频尺寸时非常有用。例如，如果您已经通过 scale 滤镜或其他方式手动指定了缩放参数，那么使用 -noautoscale 可以避免潜在的冲突或不必要的二次缩放。
- 兼容性 ： 1 2 -noautoscale 是 FFmpeg 的一个通用参数，它影响的是视频处理的逻辑，而不是特定的硬件加速功能。 1 2 因此，它应该在所有支持 FFmpeg 的硬件平台上都能正常工作，包括：
  
  - Intel 显卡 (QSV) ： 1
  - Nvidia 显卡 (CUDA/NVENC) ： 1 2
  - AMD 显卡 (AMF) ： 5
  - CPU ： 1 4
- 潜在问题 ： 4 使用 -noautoscale 本身不会导致硬件问题。潜在的问题可能出现在您 期望自动缩放但却禁用了它 的情况下。例如，如果您将一个高分辨率视频输出到一个低分辨率的容器或播放器，并且禁用了自动缩放，那么输出的视频可能会被裁剪或者无法正确显示。这通常是由于对参数的误解或不当使用造成的，而不是硬件兼容性问题。
总而言之， -noautoscale 是一个通用的 FFmpeg 参数，其作用是禁用自动缩放。它在所有支持 FFmpeg 的硬件平台上都应该正常工作，不会引起特定的硬件问题。您只需要确保在禁用自动缩放后，视频的尺寸处理符合您的预期即可。
```

测试：
部分配置文件
```
    # 硬件解码参数，默认由FFmpeg自动判断，如果出现问题可以设为空
    hwaccel_args: [-init_hw_device, qsv=hw, -filter_hw_device, hw, -hwaccel, qsv, -hwaccel_output_format, qsv]
    # 视频编码器，NVIDIA设置为h264_nvenc，AMD设置为h264_amf，Apple用户设置为h264_videotoolbox，CPU设置为libx264
    vencoder: hevc_qsv
    # 视频编码器参数，默认恒定码率15Mbps
    vencoder_args: ['-global_quality', '32']
    # 音频编码器
    aencoder: aac
    # 音频编码器参数，默认恒定码率320Kbps
    aencoder_args: [-b:a, 192K]
    # 输出重缩放，会把输出重缩放到指定分辨率，可以设置为'WxH'直接指定输出分辨率，例如'3840x2160'（4K）
    # 也可以指定为当前视频的大小倍数，例如'1.5'，这样1080P视频将会被放大到2880x1620（这个也符合了B站的4K视频标准）
    output_resize: ~
    # 高级渲染参数
    # 请确保你明白这些参数的含义后再修改
    advanced_render_args:
      # 直接定义video filter，这里的{DANMAKU}代表弹幕文件路径
      # 注意设置filter_complex之后将会禁用fps等其他有关filter的选项
      filter_complex: subtitles=filename='{DANMAKU}',format=qsv,hwupload=extra_hw_frames=32
```
可以正确编码，性能从1080P@70提升到1080P@120