### PR TITLE
实现配置文件的动态监听和自动更新功能

### DIFF
--- a/DMR/Config/__init__.py
+++ b/DMR/Config/__init__.py
@@ -1,7 +1,8 @@
 import os
 import glob
 import yaml
-
+import logging
+import hashlib
 from copy import deepcopy
 from typing import List
 from DMR.utils import *
@@ -12,20 +13,30 @@ class Config():
     _base_config_path = 'DMR/Config/default.yml'
 
     def __init__(self, global_config_path:str, replay_config_path:List[str]) -> None:
+        self.global_config_path = global_config_path
+        self.replay_config_path_raw = replay_config_path
+        self.file_hashes = {}
+        self.logger = logging.getLogger('DMR.Config')
+        
+        self.reload()
+
+    def _get_file_hash(self, path):
+        try:
+            with open(path, 'rb') as f:
+                return hashlib.md5(f.read()).hexdigest()
+        except Exception:
+            return None
+
+    def reload(self):
         with open(self._base_config_path, 'r', encoding='utf-8') as f:
             self._base_config = yaml.safe_load(f)
 
-        self.global_config_path = global_config_path
-        if isinstance(replay_config_path, str):
-            self.replay_config_path = sorted(glob.glob(os.path.join(replay_config_path, 'DMR-**.yml')))
-        else:
-            self.replay_config_path = replay_config_path
-        
         self.global_config = deepcopy(self._base_config)
         self.replay_config = {}
 
-        with open(global_config_path, 'r', encoding='utf-8') as f:
+        with open(self.global_config_path, 'r', encoding='utf-8') as f:
             _global_config = yaml.safe_load(f)
+        self.file_hashes[self.global_config_path] = self._get_file_hash(self.global_config_path)
         
         self.global_config = merge_dict(self.global_config, _global_config)
 
@@ -35,18 +46,32 @@ class Config():
             else:
                 ToolsList.set(toolname, path)
 
-        for config_path in self.replay_config_path:
+        if isinstance(self.replay_config_path_raw, str):
+            self.replay_config_paths = sorted(glob.glob(os.path.join(self.replay_config_path_raw, 'DMR-**.yml')))
+        else:
+            self.replay_config_paths = self.replay_config_path_raw
+        
+        for config_path in self.replay_config_paths:
+            self.update_task_config(config_path)
+
+    def update_task_config(self, config_path):
+        try:
             with open(config_path, 'r', encoding='utf-8') as f:
                 _replay_config = yaml.safe_load(f)
+            
+            current_hash = self._get_file_hash(config_path)
+            self.file_hashes[config_path] = current_hash
+            
             taskname = os.path.splitext(os.path.basename(config_path))[0].split('-', 1)[-1]
             replay_config = {}
-            # self.replay_config[taskname] = replay_config
+            
             common_args = _replay_config.get('common_event_args')
+            if not common_args: return None
             replay_config['common_event_args'] = deepcopy(common_args)
             
             global_download_args = self.global_config['download_args']
             dltype = _replay_config.get('download_args', {}).get('dltype', 'live')
-            replay_config['download_args'] = deepcopy(global_download_args[dltype])
+            replay_config['download_args'] = deepcopy(global_download_args.get(dltype, {}))
             if _replay_config.get('download_args'):
                 replay_config['download_args'] = merge_dict(replay_config['download_args'], _replay_config['download_args'])
 
@@ -90,6 +115,60 @@ class Config():
                             replay_config['clean_args'][clean_file_types].append(clean_config)
 
             self.replay_config[taskname] = deepcopy(replay_config)
+            return taskname
+        except Exception as e:
+            self.logger.error(f"Error loading config {config_path}: {e}")
+            return None
+
+    def check_update(self):
+        updated_tasks = []
+        new_tasks = []
+        deleted_tasks = []
+        
+        # Check global config
+        try:
+            current_hash = self._get_file_hash(self.global_config_path)
+            if current_hash != self.file_hashes.get(self.global_config_path):
+                self.file_hashes[self.global_config_path] = current_hash
+                return 'global', None
+        except Exception:
+            pass 
+
+        # Check replay configs
+        if isinstance(self.replay_config_path_raw, str):
+            current_files = set(glob.glob(os.path.join(self.replay_config_path_raw, 'DMR-**.yml')))
+        else:
+            current_files = set(self.replay_config_path_raw)
+
+        old_files = set(self.replay_config_paths)
+        
+        for f in current_files - old_files:
+            new_tasks.append(f)
+        
+        for f in old_files - current_files:
+            deleted_tasks.append(f)
+            # Remove hash for deleted file
+            if f in self.file_hashes:
+                del self.file_hashes[f]
+            
+        for f in current_files & old_files:
+            try:
+                current_hash = self._get_file_hash(f)
+                if current_hash != self.file_hashes.get(f):
+                    updated_tasks.append(f)
+                    # Note: we don't update self.file_hashes[f] here, it will be updated in update_task_config
+            except Exception:
+                pass
+        
+        if new_tasks or deleted_tasks or updated_tasks:
+            self.replay_config_paths = list(current_files)
+            return 'tasks', {
+                'new': list(new_tasks),
+                'deleted': list(deleted_tasks),
+                'updated': list(updated_tasks)
+            }
+        
+        return None, None
 
     def get_config(self, name):
         return self.global_config.get(name)

--- a/DMR/__init__.py
+++ b/DMR/__init__.py
@@ -5,10 +5,27 @@ import threading
 import json
 import time
 import logging
+from watchdog.observers import Observer
+from watchdog.events import FileSystemEventHandler
 
 from .engine import DMREngine
 from .Config import Config
 
+class ConfigEventHandler(FileSystemEventHandler):
+    def __init__(self, dmr):
+        self.dmr = dmr
+        self.last_check = 0
+        self.debounce_interval = 1.0
+
+    def on_any_event(self, event):
+        if event.is_directory:
+            return
+        filename = os.path.basename(event.src_path)
+        if filename == 'global.yml' or (filename.startswith('DMR-') and filename.endswith('.yml')):
+            if time.time() - self.last_check < self.debounce_interval:
+                return
+            self.last_check = time.time()
+            self.dmr.check_config_update()
 
 class DanmakuRender():
     def __init__(self, config:Config, **kwargs) -> None:
@@ -18,6 +35,7 @@ class DanmakuRender():
         self.stoped = True
         self.engine_args = self.config.get_config('dmr_engine_args')
         self.engine = DMREngine()
+        self.observer = None
 
     def start(self):
         self.stoped = False
@@ -35,54 +53,79 @@ class DanmakuRender():
             replay_config = self.config.get_replay_config(taskname)
             self.engine.add_task(taskname, replay_config)
 
+        if self.engine_args['dynamic_config']:
+            self.start_watchdog()
+
         threading.Thread(target=self._monintor, daemon=True).start()
+
+    def start_watchdog(self):
+        self.observer = Observer()
+        event_handler = ConfigEventHandler(self)
+        
+        # Watch global config directory (parent of global.yml)
+        global_config_dir = os.path.dirname(os.path.abspath(self.config.global_config_path))
+        self.observer.schedule(event_handler, global_config_dir, recursive=False)
+        
+        # Watch task config directory
+        if isinstance(self.config.replay_config_path_raw, str):
+            task_config_dir = self.config.replay_config_path_raw
+            if task_config_dir != global_config_dir:
+                 self.observer.schedule(event_handler, task_config_dir, recursive=False)
+        else:
+             # If list of paths, watch directories of those paths
+             # This is a bit complex if they are scattered. 
+             # Assuming they are in the same dir or we watch common parents.
+             # For simplicity, if raw is list, we iterate and watch unique dirs.
+             watched_dirs = set()
+             for path in self.config.replay_config_path_raw:
+                 d = os.path.dirname(os.path.abspath(path))
+                 if d not in watched_dirs:
+                     self.observer.schedule(event_handler, d, recursive=False)
+                     watched_dirs.add(d)
+
+        self.observer.start()
+        self.logger.info("Config watchdog started.")
+
+    def check_config_update(self):
+        try:
+            update_type, update_info = self.config.check_update()
+            
+            if update_type == 'global':
+                self.logger.info('检测到全局配置更新，请重启程序以生效。')
+            
+            elif update_type == 'tasks':
+                for config_path in update_info['new']:
+                    taskname = self.config.update_task_config(config_path)
+                    if taskname:
+                        self.logger.info(f'检测到新任务配置文件: {taskname}，正在添加任务...')
+                        self.engine.add_task(taskname, self.config.get_replay_config(taskname))
+                
+                for config_path in update_info['deleted']:
+                    taskname = os.path.splitext(os.path.basename(config_path))[0].split('-', 1)[-1]
+                    self.logger.info(f'检测到任务配置文件删除: {taskname}，正在停止任务...')
+                    self.engine.del_task(taskname)
+                    if taskname in self.config.replay_config:
+                        del self.config.replay_config[taskname]
+
+                for config_path in update_info['updated']:
+                    taskname = os.path.splitext(os.path.basename(config_path))[0].split('-', 1)[-1]
+                    self.logger.info(f'检测到任务配置文件更新: {taskname}，正在重启任务...')
+                    
+                    self.engine.del_task(taskname)
+                    time.sleep(5) 
+                    
+                    new_taskname = self.config.update_task_config(config_path)
+                    if new_taskname:
+                        self.engine.add_task(new_taskname, self.config.get_replay_config(new_taskname))
+
+        except Exception as e:
+            self.logger.error(f'动态载入配置文件错误:')
+            self.logger.exception(e)
 
     def _monintor(self):
         REFRESH_INTERVAL = 60
         time.sleep(REFRESH_INTERVAL)
-        task_buffer = {}
         while not self.stoped:
-            # dynamic load config
-            if self.engine_args['dynamic_config']:
-                try:
-                    new_config = Config(self.config.global_config_path, self.engine_args.get('dynamic_config_path'))
-                    new_tasks = set(new_config.get_replaytasks()) - set(self.config.get_replaytasks())
-                    del_tasks = set(self.config.get_replaytasks()) - set(new_config.get_replaytasks())
-                    for nt in new_tasks:
-                        if task_buffer.get(nt) is None:
-                            task_buffer[nt] = 1
-                        else:
-                            task_buffer[nt] += 1
-                    for dt in del_tasks:
-                        if task_buffer.get(dt) is None:
-                            task_buffer[dt] = -1
-                        else:
-                            task_buffer[dt] -= 1
-                    
-                    for taskname, count in list(task_buffer.items()):
-                        if taskname not in new_tasks and count > 0:
-                            task_buffer[taskname] -= 1
-                        if taskname not in del_tasks and count < 0:
-                            task_buffer[taskname] += 1
-                        if count > 2:
-                            self.logger.info(f'即将动态载入任务 {taskname}.')
-                            new_task_config = new_config.get_replay_config(taskname)
-                            self.logger.debug(f'New Task {taskname} Config:\n{json.dumps(new_task_config, indent=4, ensure_ascii=False)}')
-                            self.config.replay_config[taskname] = new_task_config
-                            self.engine.add_task(taskname, new_task_config)
-                            task_buffer.pop(taskname)
-                        elif count < -2:
-                            self.logger.info(f'即将动态取消任务 {taskname}.')
-                            self.engine.del_task(taskname)
-                            self.config.replay_config.pop(taskname)
-                            task_buffer.pop(taskname)
-                        elif count == 0:
-                            task_buffer.pop(taskname)
-
-                except Exception as e:
-                    self.logger.error(f'动态载入配置文件错误:')
-                    self.logger.exception(e)
-
             # clean temp file
             files = os.listdir('.temp')
             for file in files:
@@ -109,4 +152,7 @@ class DanmakuRender():
 
     def stop(self):
         self.stoped = True
+        if self.observer:
+            self.observer.stop()
+            self.observer.join()
         self.engine.stop()


### PR DESCRIPTION
代码更改较多
**新功能比较激进，可能需要更广泛的测试**
本人在非生产环境下测试通过。

实现配置文件的动态监听和自动更新功能
添加配置文件变更监听机制，使用watchdog监控配置目录变化
重构配置加载逻辑，支持文件哈希校验和增量更新
新增任务配置的动态添加、删除和更新功能
移除旧的动态配置轮询机制，改为事件驱动方式