### PR TITLE
修复了运行render_only报错的问题

### DIFF
--- a/DMR/Config/__init__.py
+++ b/DMR/Config/__init__.py
@@ -12,9 +12,9 @@ from DMR.utils import filename_to_taskname, merge_dict, ToolsList
 class Config():
     _base_config_path = 'DMR/Config/default.yml'
 
-    def __init__(self, global_config_path:str) -> None:
+    def __init__(self, global_config_path:str, replay_config_path:str=None) -> None:
         self.global_config_path = global_config_path
-        self.replay_config_path_raw = []
+        self.replay_config_path_raw = [replay_config_path] if replay_config_path else None
         self.replay_config_paths:List[str] = []
         self.file_hashes = {}
         self.logger = logging.getLogger(__name__)
@@ -49,7 +49,9 @@ class Config():
                 ToolsList.set(toolname, path)
 
         dmr_engine_args = self.global_config.get('dmr_engine_args', {})
-        self.replay_config_path_raw = dmr_engine_args.get('config_path', ['./configs'])
+        if self.replay_config_path_raw is None:
+            self.replay_config_path_raw = dmr_engine_args.get('config_path', ['./configs'])
+        
         if isinstance(self.replay_config_path_raw, str):
             self.replay_config_path_raw = [self.replay_config_path_raw]
 

--- a/DMR/Render/__init__.py
+++ b/DMR/Render/__init__.py
@@ -43,8 +43,8 @@ class Render():
                         if task.get('video'):
                             task['video'] = VideoInfo(**task['video'])
                             # Update config as well
-                            # if 'config' in task and 'video' in task['config']:
-                            #     task['config']['video'] = task['video']
+                            if 'config' in task and 'video' in task['config']:
+                                task['config']['video'] = task['video']
                         self.failed_tasks[uuid] = task
                 self.logger.info(f'Loaded {len(self.failed_tasks)} failed render tasks.')
             except Exception as e:
@@ -120,7 +120,7 @@ class Render():
                 'args': config.get('args', {}),
                 'video': config.get('video'),
                 'output': config.get('output'),
-                # 'config': config,
+                'config': config,
                 'status': 'waiting',
             }
             self.render_tasks[task['uuid']] = task
@@ -149,7 +149,7 @@ class Render():
                     request_id=task['request_id'],
                     dtype='dict',
                     data={
-                        # 'config': task['config'],
+                        'config': task.get('config'),
                         'output': desc,
                     },
                 )

--- a/DMR/Uploader/__init__.py
+++ b/DMR/Uploader/__init__.py
@@ -48,8 +48,8 @@ class Uploader():
                                 restored_files.append(VideoInfo(**f))
                             task['files'] = restored_files
                             # Also update files in config
-                            # if 'config' in task and 'files' in task['config']:
-                            #     task['config']['files'] = restored_files
+                            if 'config' in task and 'files' in task['config']:
+                                task['config']['files'] = restored_files
                         self.failed_tasks[uuid] = task
                 self.logger.info(f'Loaded {len(self.failed_tasks)} failed upload tasks.')
             except Exception as e:
@@ -141,7 +141,7 @@ class Uploader():
                 'args': config.get('args', {}),
                 'files': config.get('files'),
                 'stream_queue': stream_queue,
-                # 'config': config,
+                'config': config,
                 'status': 'waiting',
             }
             self.upload_tasks[task['uuid']] = task
@@ -158,7 +158,8 @@ class Uploader():
                 # ignore stream uploads
                 if task.get('stream_queue'):
                     task['stream_queue'] = None
-                    task['config']['stream_queue'] = None
+                    if task.get('config'):
+                        task['config']['stream_queue'] = None
                 else:
                     self.failed_tasks[task['uuid']] = task
                     self.save_failed_tasks()
@@ -179,7 +180,7 @@ class Uploader():
                     request_id=task['request_id'],
                     dtype='dict',
                     data={
-                        'config': task['config'],
+                        'config': task.get('config'),
                     },
                 )
 

--- a/DMR/utils/dataclass.py
+++ b/DMR/utils/dataclass.py
@@ -85,6 +85,11 @@ class StreamInfo(cpdict):
         self.streamer = streamer
         self.title = title
         self.description = description
+        if isinstance(stream_start_time, str):
+            try:
+                stream_start_time = datetime.fromisoformat(stream_start_time)
+            except (ValueError, TypeError):
+                pass
         self.stream_start_time = stream_start_time
         self.resolution = resolution
         self.cover_url = cover_url
@@ -110,6 +115,11 @@ class FileInfo(cpdict):
         self.dtype = dtype
         self.path = path
         self.size = size
+        if isinstance(ctime, str):
+            try:
+                ctime = datetime.fromisoformat(ctime)
+            except (ValueError, TypeError):
+                pass
         self.ctime = ctime
         super().__init__(
                 file_id=file_id,
@@ -138,6 +148,8 @@ class VideoInfo(FileInfo):
                 src_video_id:str=None,
                 dm_file_id:str=None,
                 **kwargs):
+        if isinstance(streamer, dict):
+            streamer = StreamerInfo(**streamer)
         self.streamer = streamer
         self.duration = duration
         self.resolution = resolution

--- a/DMR/utils/utils.py
+++ b/DMR/utils/utils.py
@@ -52,11 +52,12 @@ class DateTimeDecoder(json.JSONDecoder):
         super().__init__(object_hook=self.object_hook, *args, **kwargs)
     
     def object_hook(self, obj):
-        if isinstance(obj, str):
-            try:
-                return datetime.fromisoformat(obj)
-            except ValueError:
-                pass
+        for k, v in obj.items():
+            if isinstance(v, str):
+                try:
+                    obj[k] = datetime.fromisoformat(v)
+                except (ValueError, TypeError):
+                    pass
         return obj
 
 


### PR DESCRIPTION
今天运行render_only报错了
```
render_only.py 现在运行这个报错root@haha:/hdd1/rec# /hdd1/rec/myenv/bin/python ./render_only.py
ERROR:root:Config.__init__() takes 2 positional arguments but 3 were given
Traceback (most recent call last):
File "/hdd1/rec/./render_only.py", line 140, in <module>
main()
File "/hdd1/rec/./render_only.py", line 31, in main
config = Config(args.global_config, args.config)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Config.__init__() takes 2 positional arguments but 3 were given
渲染错误, Config.__init__() takes 2 positional arguments but 3 were given^CTraceback (most recent call last):
File "/hdd1/rec/./render_only.py", line 140, in <module>
main()
File "/hdd1/rec/./render_only.py", line 31, in main
config = Config(args.global_config, args.config)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Config.__init__() takes 2 positional arguments but 3 were given
```
这一版修复了